### PR TITLE
Potential fix for code scanning alert no. 15: Failure to use secure cookies

### DIFF
--- a/app/backend/Routes/api_routes.py
+++ b/app/backend/Routes/api_routes.py
@@ -134,7 +134,7 @@ async def login_or_register(request: AuthRequest) -> SessionResponse:
             key=SESSION_COOKIE_NAME,
             value=session_token,
             httponly=True,
-            secure=False,  # Set to True in production with HTTPS
+            secure=True,  # Secure cookie: Only sent via HTTPS
             samesite="lax",
             max_age=3600  # 1 hour
         )
@@ -174,7 +174,7 @@ async def login_or_register(request: AuthRequest) -> SessionResponse:
             key=SESSION_COOKIE_NAME,
             value=session_token,
             httponly=True,
-            secure=False,  # Set to True in production with HTTPS
+            secure=True,  # Secure cookie: Only sent via HTTPS
             samesite="lax",
             max_age=3600  # 1 hour
         )
@@ -191,7 +191,7 @@ async def logout(request: Request) -> dict:
         invalidate_session(session_token)
     
     response = Response(content='{"success": true, "message": "Logged out successfully"}')
-    response.delete_cookie(SESSION_COOKIE_NAME)
+    response.delete_cookie(SESSION_COOKIE_NAME, secure=True)
     response.headers["Content-Type"] = "application/json"
     return response
 


### PR DESCRIPTION
Potential fix for [https://github.com/Frank1o3/bedrock-server/security/code-scanning/15](https://github.com/Frank1o3/bedrock-server/security/code-scanning/15)

To fix the failure to use secure cookies, set the `secure` argument to `True` in all `response.set_cookie` calls that set the session cookie. This will ensure that cookies are only sent over HTTPS connections, thus mitigating the risk of session hijacking over insecure channels. In your code, replace all instances of `secure=False` with `secure=True` for session-related cookies in the `login_or_register` function, for both login and registration branches. Optionally, you may also wish to set `secure=True` in the `logout` endpoint's `delete_cookie` call, but FastAPI's `delete_cookie` uses secure only if specified. For maximal security, explicitly set `secure=True` in all places. No additional imports or methods are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
