### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,4 +1,6 @@
 name: Release Docker
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:  # only run manually


### PR DESCRIPTION
Potential fix for [https://github.com/Frank1o3/bedrock-server/security/code-scanning/16](https://github.com/Frank1o3/bedrock-server/security/code-scanning/16)

The best way to fix this problem is to explicitly set the `permissions` block in the workflow or job. Given there is only a single job and none of the steps require write permission to the repository, the minimal permission of `contents: read` should be specified to follow the principle of least privilege.

Practically, this involves adding a `permissions: contents: read` block either:
- at the top level of the workflow (recommended for single-job workflows), or
- inside the single job.

Here, it is simplest and most conventional to add it directly beneath the workflow `name` (between lines 1 and 3), so it applies to all jobs by default.

No new imports, methods, or complex changes are needed; just a single block addition in the YAML file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
